### PR TITLE
fix: update Cosmos Keyring setup links in peggo documentation

### DIFF
--- a/.gitbook/nodes/validators/mainnet/peggo.md
+++ b/.gitbook/nodes/validators/mainnet/peggo.md
@@ -183,7 +183,7 @@ Please note that the default keyring backend is `file` and that as such peggo wi
 
 To use the default injectived key configuration, you should set the keyring path to the home directory of your injectived node, e.g., `~/.injectived`.
 
-You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/main/run-node/keyring.html).
+You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html).
 
 #### **Option 2. Cosmos Private Key (Unsafe)**
 
@@ -279,7 +279,7 @@ journalctl -f -u peggo
 This is an advanced DevOps topic, consult with your sysadmin.
 {% endhint %}
 
-Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/master/run-node/keyring.html). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
+Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
 
 Some sections of the Injective Staking documentation will guide you through using this key for governance purposes, i.e. submitting transactions and setting up an Ethereum bridge. In order to protect the keys from unauthorized access, even when the keyring passphrase is leaked via configs, you can set OS permissions to allow disk access to `injectived` / `peggo` processes only.
 

--- a/.gitbook/nodes/validators/testnet/testnet-peggo.md
+++ b/.gitbook/nodes/validators/testnet/testnet-peggo.md
@@ -226,7 +226,7 @@ Please note that the default keyring backend is `file` and that, as such, peggo 
 
 To use the default injectived key configuration, you should set the keyring path to the home directory of your injectived node, e.g. `~/.injectived`.
 
-You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/master/run-node/keyring.html).
+You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html).
 
 #### **Option 2. Cosmos Private Key (Unsafe)**
 
@@ -372,7 +372,7 @@ journalctl -f -u peggo
 This is an advanced DevOps topic, consult with your sysadmin.
 {% endhint %}
 
-Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/master/run-node/keyring.html). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually, the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
+Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually, the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
 
 Some sections of the Injective Staking documentation will guide you through using this key for governance purposes, i.e., submitting transactions and setting up an Ethereum bridge. In order to protect the keys from unauthorized access, even when the keyring passphrase is leaked via configs, you can set OS permissions to allow disk access to `injectived` / `peggo` processes only.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated links to the Cosmos Keyring setup documentation for both Mainnet and Testnet configurations, directing users to version 0.46.
	- Clarified instructions for configuring the Peggo relayer, including the correct path for configuration files and recommended key management practices.
	- Enhanced security warnings regarding the use of plaintext private keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->