### PR TITLE
f/fixing links and add reference

### DIFF
--- a/.gitbook/developers/cosmwasm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/cosmwasm-developers/your-first-smart-contract.md
@@ -485,7 +485,7 @@ yes 12345678 | injectived tx wasm store artifacts/my_first_contract.wasm \
 --from=$(echo $INJ_ADDRESS) \
 --chain-id="injective-888" \
 --yes --fees=1000000000000000inj --gas=2000000 \
---node=https://sentry.testnet.tm.injective.network:443
+--node=https://testnet.sentry.tm.injective.network:443
 ```
 
 **Output:**
@@ -520,7 +520,7 @@ There are different ways to find the code that you just stored:
 To query the transaction use the `txhash` and verify the contract was deployed.
 
 ```sh
-injectived query tx 912458AA8E0D50A479C8CF0DD26196C49A65FCFBEEB67DF8A2EA22317B130E2C --node=https://sentry.testnet.tm.injective.network:443
+injectived query tx 912458AA8E0D50A479C8CF0DD26196C49A65FCFBEEB67DF8A2EA22317B130E2C --node=https://testnet.sentry.tm.injective.network:443
 ```
 
 Inspecting the output more closely, we can see the `code_id` of `290` for the uploaded contract:
@@ -619,7 +619,7 @@ yes 12345678 | injectived tx wasm instantiate $CODE_ID $INIT \
 --yes --fees=1000000000000000inj \
 --gas=2000000 \
 --no-admin \
---node=https://sentry.testnet.tm.injective.network:443
+--node=https://testnet.sentry.tm.injective.network:443
 ```
 
 **Output:**
@@ -643,12 +643,12 @@ txhash: 01804F525FE336A5502E3C84C7AE00269C7E0B3DC9AA1AB0DDE3BA62CF93BE1D
 {% hint style="info" %}
 You can find the contract address and metadata by:
 
-* Looking on the [Testnet Explorer](https://testnet.explorer.injective.network/contracts/)
+* Looking on the [Testnet Explorer](https://www.injscan.com/smart-contracts/)
 * Querying the [ContractsByCode](https://k8s.testnet.lcd.injective.network/swagger/#/Query/ContractsByCode) and [ContractInfo](https://k8s.testnet.lcd.injective.network/swagger/#/Query/ContractInfo) APIs
 * Querying through the CLI
 
 ```bash
-injectived query wasm contract inj1ady3s7whq30l4fx8sj3x6muv5mx4dfdlcpv8n7 --node=https://sentry.testnet.tm.injective.network:443
+injectived query wasm contract inj1ady3s7whq30l4fx8sj3x6muv5mx4dfdlcpv8n7 --node=https://testnet.sentry.tm.injective.network:443
 ```
 {% endhint %}
 
@@ -659,7 +659,7 @@ As we know from earlier, the only QueryMsg we have is `get_count`.
 ```bash
 GET_COUNT_QUERY='{"get_count":{}}'
 injectived query wasm contract-state smart inj1ady3s7whq30l4fx8sj3x6muv5mx4dfdlcpv8n7 "$GET_COUNT_QUERY" \
---node=https://sentry.testnet.tm.injective.network:443 \
+--node=https://testnet.sentry.tm.injective.network:443 \
 --output json
 ```
 
@@ -684,7 +684,7 @@ INCREMENT='{"increment":{}}'
 yes 12345678 | injectived tx wasm execute inj1ady3s7whq30l4fx8sj3x6muv5mx4dfdlcpv8n7 "$INCREMENT" --from=$(echo $INJ_ADDRESS) \
 --chain-id="injective-888" \
 --yes --fees=1000000000000000inj --gas=2000000 \
---node=https://sentry.testnet.tm.injective.network:443 \
+--node=https://testnet.sentry.tm.injective.network:443 \
 --output json
 ```
 
@@ -706,7 +706,7 @@ yes 12345678 | injectived tx wasm execute inj1ady3s7whq30l4fx8sj3x6muv5mx4dfdlcp
 --from=$(echo $INJ_ADDRESS) \
 --chain-id="injective-888" \
 --yes --fees=1000000000000000inj --gas=2000000 \
---node=https://sentry.testnet.tm.injective.network:443 \
+--node=https://testnet.sentry.tm.injective.network:443 \
 --output json
 ```
 

--- a/.gitbook/guides/launch-a-token.md
+++ b/.gitbook/guides/launch-a-token.md
@@ -58,7 +58,7 @@ To get your token visible on Injective dApps, you have to submit its metadata.&#
 injectived tx tokenfactory set-denom-metadata "My Token Description" 'factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak' AKK AKCoin AK '' '' '[
 {"denom":"factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak","exponent":0,"aliases":[]},
 {"denom":"AKK","exponent":6,"aliases":[]}
-]' 6 --from=YOUR_KEY --chain-id=injective-888 --node=https://sentry.testnet.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
+]' 6 --from=YOUR_KEY --chain-id=injective-888 --node=https://testnet.sentry.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
 ```
 
 This command expects the following arguments:
@@ -71,7 +71,7 @@ This command expects the following arguments:
 Once you have created your token and submitted the token metadata, it's time to mint your tokens.&#x20;
 
 ```bash
-injectived tx tokenfactory mint 1000000factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak --from=gov --chain-id=injective-888 --node=https://sentry.testnet.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
+injectived tx tokenfactory mint 1000000factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak --from=gov --chain-id=injective-888 --node=https://testnet.sentry.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
 ```
 
 This command will mint 1 token, assuming your token has 6 decimals.&#x20;
@@ -81,7 +81,7 @@ This command will mint 1 token, assuming your token has 6 decimals.&#x20;
 The admin of the token, can also burn the tokens.&#x20;
 
 ```bash
-injectived tx tokenfactory burn 1000000factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak --from=gov --chain-id=injective-888 --node=https://sentry.testnet.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
+injectived tx tokenfactory burn 1000000factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak --from=gov --chain-id=injective-888 --node=https://testnet.sentry.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
 ```
 
 5. **Change admin**
@@ -89,7 +89,7 @@ injectived tx tokenfactory burn 1000000factory/inj17vytdwqczqz72j65saukplrktd4gy
 It's recommended once you have minted the initial supply to change admin to the `null` address to make sure that the supply of the token cannot be manipulated. Once again, the admin of the token can mint and burn supply anytime. The `NEW_ADDRESS`, as explained above in most of the cases should be set to `inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49`.&#x20;
 
 ```bash
-injectived tx tokenfactory change-admin factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak NEW_ADDRESS --from=gov --chain-id=injective-888 --node=https://sentry.testnet.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
+injectived tx tokenfactory change-admin factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/ak NEW_ADDRESS --from=gov --chain-id=injective-888 --node=https://testnet.sentry.tm.injective.network:443 --gas-prices=500000000inj --gas 1000000
 ```
 
 {% hint style="info" %}
@@ -97,7 +97,7 @@ The examples above are for testnet. If you want to run them on mainnet, do the f
 
 `injective-888` > `injective-1`
 
-`https://sentry.testnet.tm.injective.network:443` > `http://sentry.tm.injective.network:443`
+`https://testnet.sentry.tm.injective.network:443` > `http://sentry.tm.injective.network:443`
 {% endhint %}
 
 #### Using Cosmwasm

--- a/.gitbook/references.md
+++ b/.gitbook/references.md
@@ -22,6 +22,7 @@ Developer tools and resources to get you building on Injective
 | [Real-time Status (Mainnet)](https://status.injective.network/)                               | Real-time status of the endpoints and of the Injective network                                                              |
 | [Real-time Status (Testnet)](https://testnet.status.injective.network)                        | Real-time status of the endpoints and of the Injective testnet network                                                      |
 | [Cosmovisor](nodes/validators/cosmosvisor.md)                                                 | Small process manager around Cosmos SDK binaries that monitors the governance module                                        |
+| [CosmosSDK](https://docs.cosmos.network/v0.52/build)                                          | The Cosmos SDK documentation serving as a valuable resource for developers integrating with the Injective ecosystem                                        |
 
 ### Ecosystem Tools and Resources
 


### PR DESCRIPTION
Fixing wrong links in docs
Add one reference link to CosmosSDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated command examples to point to the correct testnet and mainnet endpoints.
	- Revised explorer link references for accurate transaction tracking.
	- Added a helpful developer resource link to Cosmos SDK documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->