### PR TITLE
chore: change private to premium endpoints

### DIFF
--- a/.gitbook/SUMMARY.md
+++ b/.gitbook/SUMMARY.md
@@ -198,7 +198,7 @@
     * [Testnet Peggo](nodes/validators/testnet/testnet-peggo.md)
   * [Cosmosvisor](nodes/validators/cosmosvisor.md)
 * [Public Endpoints](nodes/public-endpoints.md)
-* [Private Nodes](nodes/private-nodes.md)
+* [Premium Endpoints](nodes/private-nodes.md)
 * [Injective Indexer Setup](https://injective.notion.site/Injective-Exchange-Service-Setup-Guide-7e59980634d54991862300670583d46a)
 
 ## Traders

--- a/.gitbook/nodes/private-nodes.md
+++ b/.gitbook/nodes/private-nodes.md
@@ -1,10 +1,10 @@
 ---
 description: >-
-  As a developer, you may be interested in having a private/dedicated node or
+  As a developer, you may be interested in having a dedicated node or
   indexing solutions powering your dApp.
 ---
 
-# Private Nodes
+# Premium Endpoints
 
 Here is a list of external providers offering private Injective infrastructure services. For more information, click on their websites below:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed the service label from "Private Nodes" to "Premium Endpoints" in the documentation overview.
  - Revised the detailed section description to align with the new terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->