### PR TITLE
Use k8s URLs for public evm endpoints 

### DIFF
--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -26,7 +26,7 @@ forge --version
 
 ```
 [rpc_endpoints]
-injectiveEvm = "https://testnet.sentry.chain.json-rpc.injective.network/"
+injectiveEvm = "https://k8s.testnet.json-rpc.injective.network/"
 ```
 
 ## Deploying

--- a/.gitbook/developers/evm-developers/technical-information/network-information.md
+++ b/.gitbook/developers/evm-developers/technical-information/network-information.md
@@ -9,7 +9,7 @@ description: Essential information about the Injective EVM network
 * Injective Chain Id: `injective-888`
 * Ethereum Chain Id: `1439`
 * JSON-RPC Endpoint: [https://k8s.testnet.json-rpc.injective.network/](https://k8s.testnet.json-rpc.injective.network/)
-* WS Endpoint: [https://testnet.sentry.chain.ws.injective.network/](https://testnet.sentry.chain.ws.injective.network/)
+* WS Endpoint: [https://k8s.testnet.ws.injective.network/](https://k8s.testnet.ws.injective.network/)
 * Explorer: [https://testnet.blockscout.injective.network/blocks](https://testnet.blockscout.injective.network/blocks) ([Mirror](https://testnet-injective.cloud.blockscout.com/blocks) by BlockScout)
 
 {% hint style="info" %}

--- a/.gitbook/developers/evm-developers/technical-information/network-information.md
+++ b/.gitbook/developers/evm-developers/technical-information/network-information.md
@@ -8,7 +8,7 @@ description: Essential information about the Injective EVM network
 
 * Injective Chain Id: `injective-888`
 * Ethereum Chain Id: `1439`
-* JSON-RPC Endpoint: [https://testnet.sentry.chain.json-rpc.injective.network/](https://testnet.sentry.chain.json-rpc.injective.network/)
+* JSON-RPC Endpoint: [https://k8s.testnet.json-rpc.injective.network/](https://k8s.testnet.json-rpc.injective.network/)
 * WS Endpoint: [https://testnet.sentry.chain.ws.injective.network/](https://testnet.sentry.chain.ws.injective.network/)
 * Explorer: [https://testnet.blockscout.injective.network/blocks](https://testnet.blockscout.injective.network/blocks) ([Mirror](https://testnet-injective.cloud.blockscout.com/blocks) by BlockScout)
 

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -35,8 +35,7 @@ forge --version
 
 ```
 [rpc_endpoints]
-injectiveEvm = " 
-https://testnet.sentry.chain.json-rpc.injective.network/"
+injectiveEvm = "https://k8s.testnet.json-rpc.injective.network/"
 ```
 
 ## Development
@@ -91,8 +90,7 @@ You can read more about the process of [testnet-deployment.md](guides/testnet-de
 Let's query the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
 
 ```bash
-cast sig "function number() returns (uint256)"
-0x8381f58a
+cast sig "function number() returns (uint256)" 0x8381f58a
 
 cast call --rpc-url injectiveEvm {SmartContractAddress} 0x8381f58a
 ```
@@ -110,8 +108,7 @@ cast call --rpc-url injectiveEvm {SmartContractAddress} 0x8381f58a
 Let's make a transaction and change the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
 
 ```bash
-cast sig "function increment()"
-0xd09de08a
+cast sig "function increment()" 0xd09de08a
 
 cast send --legacy --rpc-url injectiveEvm --private-key {YourPrivateKey} {SmartContractAddress} 0xd09de08a
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Injective EVM testnet RPC, JSON-RPC, and WebSocket endpoint URLs to use new "k8s.testnet" subdomains.
  - Improved usage examples for the `cast sig` command by consolidating function signature and selector into a single command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->