### PR TITLE
chore: update link in join-a-network.md to fetch latest release binary

### DIFF
--- a/.gitbook/nodes/getting-started/running-a-node/join-a-network.md
+++ b/.gitbook/nodes/getting-started/running-a-node/join-a-network.md
@@ -155,7 +155,7 @@ Node operators should deploy bare metal servers to achieve optimal performance. 
 See the [Injective releases repo](https://github.com/InjectiveLabs/testnet/releases) for the most recent releases. Non-validator node operators do not need to install `peggo`.
 
 ```bash
-wget https://github.com/InjectiveLabs/testnet/releases/download/v1.12.9-testnet-1703762556/linux-amd64.zip
+wget -L https://github.com/InjectiveLabs/testnet/releases/latest/download/linux-amd64.zip
 unzip linux-amd64.zip
 sudo mv peggo /usr/bin
 sudo mv injectived /usr/bin
@@ -258,7 +258,7 @@ Node operators should deploy bare metal servers to achieve optimal performance. 
 See the [Injective chain releases repo](https://github.com/InjectiveLabs/injective-chain-releases/releases/) for the most recent releases. Non-validator node operators do not need to install `peggo`.
 
 ```bash
-wget https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.14.1-1740773301/linux-amd64.zip
+wget -L https://github.com/InjectiveLabs/injective-chain-releases/releases/latest/download/linux-amd64.zip
 unzip linux-amd64.zip
 sudo mv peggo /usr/bin
 sudo mv injectived /usr/bin

--- a/.gitbook/nodes/getting-started/running-a-node/join-a-network.md
+++ b/.gitbook/nodes/getting-started/running-a-node/join-a-network.md
@@ -155,7 +155,7 @@ Node operators should deploy bare metal servers to achieve optimal performance. 
 See the [Injective releases repo](https://github.com/InjectiveLabs/testnet/releases) for the most recent releases. Non-validator node operators do not need to install `peggo`.
 
 ```bash
-wget -L https://github.com/InjectiveLabs/testnet/releases/latest/download/linux-amd64.zip
+wget https://github.com/InjectiveLabs/testnet/releases/latest/download/linux-amd64.zip
 unzip linux-amd64.zip
 sudo mv peggo /usr/bin
 sudo mv injectived /usr/bin
@@ -258,7 +258,7 @@ Node operators should deploy bare metal servers to achieve optimal performance. 
 See the [Injective chain releases repo](https://github.com/InjectiveLabs/injective-chain-releases/releases/) for the most recent releases. Non-validator node operators do not need to install `peggo`.
 
 ```bash
-wget -L https://github.com/InjectiveLabs/injective-chain-releases/releases/latest/download/linux-amd64.zip
+wget https://github.com/InjectiveLabs/injective-chain-releases/releases/latest/download/linux-amd64.zip
 unzip linux-amd64.zip
 sudo mv peggo /usr/bin
 sudo mv injectived /usr/bin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for downloading node binaries to use a simplified command that always fetches the latest release for both Testnet and Mainnet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->