### PR TITLE
docs: "my first smart contract" and "testnet deployment" pages misc fixes

### DIFF
--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -45,6 +45,8 @@ cd path/to/your/project
 Your private key should have INJ on the Injective network. A transaction will be created which requires a gas fee. You can request EVM testnet funds [here](https://testnet.faucet.injective.network/)
 {% endhint %}
 
+This command creates a transaction, but simply displays it without submitting it to the network. Therefore the smart contract does not get deployed.
+
 ```shell
 # Simulating
 forge create \
@@ -55,6 +57,8 @@ forge create \
   {YourPrivateKey}
 ```
 
+This command does the same as above, but submits it to the network. Therefore the smart contract should get deployed.
+
 ```shell
 # Broadcasting
 forge create \
@@ -64,6 +68,8 @@ forge create \
   --private-key {YourPrivateKey} \
   --broadcast
 ```
+
+Be sure to copy the address at which the smart contrct was deployed, as you will need to use it in subsequent commands.
 
 ### Verifying on Blockscout
 

--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -49,7 +49,7 @@ Your private key should have INJ on the Injective network. A transaction will be
 <strong>forge create src/{YourContract}.sol:{ContractName} --rpc-url injectiveEvm --private-key {YourPrivateKey}
 </strong>
 # Broadcasting
-forge create src/{YourContract}.sol:{ContractName} --rpc-url injectiveEvm --private-key {YourPrivateKey} --broadcast
+forge create src/{YourContract}.sol:{ContractName} --rpc-url injectiveEvm --legacy --private-key {YourPrivateKey} --broadcast
 </code></pre>
 
 ### Verifying on Blockscout

--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -45,12 +45,25 @@ cd path/to/your/project
 Your private key should have INJ on the Injective network. A transaction will be created which requires a gas fee. You can request EVM testnet funds [here](https://testnet.faucet.injective.network/)
 {% endhint %}
 
-<pre class="language-bash"><code class="lang-bash"># Simulating
-<strong>forge create src/{YourContract}.sol:{ContractName} --rpc-url injectiveEvm --private-key {YourPrivateKey}
-</strong>
+```shell
+# Simulating
+forge create \
+  src/{YourContract}.sol:{ContractName} \
+  --rpc-url injectiveEvm \
+  --legacy \
+  --private-key \
+  {YourPrivateKey}
+```
+
+```shell
 # Broadcasting
-forge create src/{YourContract}.sol:{ContractName} --rpc-url injectiveEvm --legacy --private-key {YourPrivateKey} --broadcast
-</code></pre>
+forge create \
+  src/{YourContract}.sol:{ContractName} \
+  --rpc-url injectiveEvm \
+  --legacy \
+  --private-key {YourPrivateKey} \
+  --broadcast
+```
 
 ### Verifying on Blockscout
 

--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -69,11 +69,14 @@ forge create \
   --broadcast
 ```
 
-Be sure to copy the address at which the smart contrct was deployed, as you will need to use it in subsequent commands.
+Be sure to copy the address at which the smart contract was deployed, as you will need to use it in subsequent commands.
+
 
 ### Verifying on Blockscout
 
-After the deployment is completed, you can verify the contract.
+After the deployment is completed, if you visit a network explorer, such as Blockscout, and search for the address of the smart contract, you will see that it has bytecode.
+
+However, to add more details you need to verify the contract.
 
 ```bash
 forge verify-contract \
@@ -84,7 +87,7 @@ forge verify-contract \
   src/{YourContract}.sol:{ContractName}
 ```
 
-After that, you can navigate to the contract address in Explorer to see the code, parsed logs, and callable methods ([example](https://k8s.testnet.evm.blockscout.injective.network/address/0x2f9f80b89ef4C9AaBcd630E62B740d6a2f3065E4)).
+After that, you can navigate to the contract address in Explorer to see the code, the ABI, parsed logs, and callable methods ([example](https://k8s.testnet.evm.blockscout.injective.network/address/0x2f9f80b89ef4C9AaBcd630E62B740d6a2f3065E4)).
 
 {% hint style="info" %}
 You can read more about foundry deploying [here](https://book.getfoundry.sh/forge/deploying), or you can check other deployment options [here](https://book.getfoundry.sh/reference/forge/forge-create). You can also read more about forge verify-contract [here](https://book.getfoundry.sh/reference/forge/forge-verify-contract).

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -61,7 +61,11 @@ We can build a simple **Counter** example and then do a transaction/query the sm
 
 ### Smart Contract Code
 
-This is just a simple Counter smart contract written in Solidity.
+Next, create a simple Counter smart contract written in Solidity.
+
+```shell
+touch src/counter.sol
+```
 
 ```solidity
 // SPDX-License-Identifier: UNLICENSED

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -102,7 +102,7 @@ You can read more about the process of [testnet-deployment.md](guides/testnet-de
 // WiP
 ```
 
-#### Using Casttive
+#### Using Foundry
 
 Let's query the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
 
@@ -120,7 +120,7 @@ cast call --rpc-url injectiveEvm {SmartContractAddress} 0x8381f58a
 // WiP
 ```
 
-#### Using Cast
+#### Using Foundry
 
 Let's make a transaction and change the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
 

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -173,4 +173,8 @@ cast send \
   0xd09de08a
 ```
 
+If you visit the smart contract address in a block exporer, you should see the new transaction registered against it.
+
+If you repeat the `cast call` command above which invoke `number()`, you should get an updated value of `1` this time.
+
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th data-type="content-ref"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>← Previous</td><td><a href="../evm-developers.md">evm-developers.md</a></td><td><a href="../evm-developers.md">evm-developers.md</a></td></tr><tr><td>Next →</td><td><a href="guides/">guides</a></td><td><a href="guides/">guides</a></td></tr></tbody></table>

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -35,7 +35,22 @@ Note that the version used in this tutorial was `1.2.3-stable`. Be sure to use t
 
 2. Add Injective EVM to your `foundry.toml`
 
+{% hint style="info" %}
+If you are starting a new project from scratch:
+
+- Create a new directory for the project
+- Create a new `foundry.toml` file inside it
+- Create an `src` subdirectory
+
+```shell
+mkdir my-first-smart-contract-inj
+cd my-first-smart-contract-inj
+touch foundry.toml
+mkdir src
 ```
+{% endhint %}
+
+```toml
 [rpc_endpoints]
 injectiveEvm = "https://k8s.testnet.json-rpc.injective.network/"
 ```

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -15,6 +15,9 @@ Building and Deploying smart contracts on Injective should be quite simple. As y
 
 ## Requirements
 
+You will need a wallet, and an account that has been funded with some Testnet INJ.
+After creating your account, be sure to copy your private key somewhere accessible, as you will need it to complete this tutorial.
+
 {% hint style="info" %}
 You can request EVM testnet funds from the official Testnet faucet [here](https://testnet.faucet.injective.network/).
 {% endhint %}

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -10,8 +10,8 @@ Building and Deploying smart contracts on Injective should be quite simple. As y
 
 1. We'll develop the smart contract,
 2. Do a [testnet-deployment.md](guides/testnet-deployment.md "mention") on the Injective's EVM Testnet,
-3. Query the smart contract using [Cast](https://book.getfoundry.sh/reference/cast/),
-4. Send a transaction to change the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/),
+3. Query the smart contract using [`cast`](https://getfoundry.sh/cast/reference/overview),
+4. Send a transaction to change the smart contract state using [`cast`](https://getfoundry.sh/cast/reference/overview),
 
 ## Requirements
 
@@ -108,7 +108,7 @@ You can read more about the process of [testnet-deployment.md](guides/testnet-de
 
 #### Using Foundry
 
-Let's query the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
+Let's query the smart contract state using [`cast`](https://getfoundry.sh/cast/reference/overview).
 
 First use `cast sig`:
 
@@ -145,7 +145,7 @@ If you have yet to perform any transactions on this smart contract, it should sh
 
 #### Using Foundry
 
-Let's make a transaction and change the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
+Let's make a transaction and change the smart contract state using [`cast`](https://getfoundry.sh/cast/reference/overview).
 
 First use `cast sig`, this time on a different function:
 

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -125,7 +125,10 @@ This should produce the following output, which is the function signature:
 We use this function signature in `cast call`, which performs the actual query:
 
 ```shell
-cast call --rpc-url injectiveEvm {SmartContractAddress} 0x8381f58a
+cast call \
+  --rpc-url injectiveEvm \
+  {SmartContractAddress} \
+  0x8381f58a
 ```
 
 This outputs the return value of invoking `number()` on your deployed smart contract.
@@ -159,7 +162,12 @@ This should produce a different function signature from befoe, since it is anoth
 We use this `cast send`, which performs the actual transaction:
 
 ```shell
-cast send --legacy --rpc-url injectiveEvm --private-key {YourPrivateKey} {SmartContractAddress} 0xd09de08a
+cast send \
+  --legacy \
+  --rpc-url injectiveEvm \
+  --private-key {YourPrivateKey} \
+  {SmartContractAddress} \
+  0xd09de08a
 ```
 
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th data-type="content-ref"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>← Previous</td><td><a href="../evm-developers.md">evm-developers.md</a></td><td><a href="../evm-developers.md">evm-developers.md</a></td></tr><tr><td>Next →</td><td><a href="guides/">guides</a></td><td><a href="guides/">guides</a></td></tr></tbody></table>

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -110,11 +110,27 @@ You can read more about the process of [testnet-deployment.md](guides/testnet-de
 
 Let's query the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
 
-```bash
-cast sig "function number() returns (uint256)" 0x8381f58a
+First use `cast sig`:
 
+```shell
+cast sig "function number() returns (uint256)"
+```
+
+This should produce the following output, which is the function signature:
+
+```text
+0x8381f58a
+```
+
+We use this function signature in `cast call`, which performs the actual query:
+
+```shell
 cast call --rpc-url injectiveEvm {SmartContractAddress} 0x8381f58a
 ```
+
+This outputs the return value of invoking `number()` on your deployed smart contract.
+
+If you have yet to perform any transactions on this smart contract, it should show `0`.
 
 ### Transactions against the Smart Contract
 
@@ -128,9 +144,21 @@ cast call --rpc-url injectiveEvm {SmartContractAddress} 0x8381f58a
 
 Let's make a transaction and change the smart contract state using [Cast](https://book.getfoundry.sh/reference/cast/)
 
-```bash
-cast sig "function increment()" 0xd09de08a
+First use `cast sig`, this time on a different function:
 
+```shell
+cast sig "function increment()"
+```
+
+This should produce a different function signature from befoe, since it is another function:
+
+```text
+0xd09de08a
+```
+
+We use this `cast send`, which performs the actual transaction:
+
+```shell
 cast send --legacy --rpc-url injectiveEvm --private-key {YourPrivateKey} {SmartContractAddress} 0xd09de08a
 ```
 

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -27,9 +27,11 @@ curl -L https://foundry.paradigm.xyz | bash
 
 To verify the installation:
 
-```
+```shell
 forge --version
 ```
+
+Note that the version used in this tutorial was `1.2.3-stable`. Be sure to use this version or later when following along.
 
 2. Add Injective EVM to your `foundry.toml`
 


### PR DESCRIPTION
Misc fixes self-recommended as low-hanging fruit based on results of a DX audit.

- [x] Should specify the minimum version  of foundry that is recommended AND the version used in creating this tutorial
- [x] should specify background tasks as well such as creating directories and opening IDE, etc
- [x] “Casttive” → “Cast” probably
- [x] specify that SC file should be created in src/Counter.sol
- [x] Multiple commands in the same box - get copied together, so cannot paste into terminal, need to paste into a scratch text file first, and then copy individually, which is a minor frustration - better to just have them split instead
- [x] Need to update the command for the EIP1559 error
	- [x] Add the -–legacy flag
	- [ ] Add explanation why Injective does not support 1559
- [x] Update commands such that they are split into multiple lines instead of the need to do horizontal scrolling
- [x] Currently the cast sig commands include the output in the command → fix this
- [x] Link to the cast command is broken
- [x] Add explanations for what to do w.r.t. Do for variable substitution
- [x] add instructions for looking at the output of the cast command, then copying the TX hash into block explorer, etc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified instructions for deploying smart contracts on the Injective EVM testnet, including more detailed deployment commands and improved guidance on contract verification.
  - Updated the smart contract tutorial to provide clearer, step-by-step instructions for using Foundry's `cast` tool, with improved prerequisites, command examples, and explanations for querying and transacting with contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->