### PR TITLE
docs: nitpick edits to the "my first smart contract" and "testnet deployment" pages

### DIFF
--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -45,7 +45,7 @@ cd path/to/your/project
 Your private key should have INJ on the Injective network. A transaction will be created which requires a gas fee. You can request EVM testnet funds [here](https://testnet.faucet.injective.network/)
 {% endhint %}
 
-This command creates a transaction, and submits it to the network. If the transaction is successful, the smart contract will be deployed, and the address it is deployed at will be output.
+This command creates a transaction and submits it to the network. If the transaction is successful, the smart contract will be deployed, and the address it is deployed at will be output.
 
 ```shell
 # Broadcasting
@@ -63,7 +63,7 @@ Be sure to copy the address at which the smart contract was deployed, as you wil
 
 After the deployment is completed, if you visit a network explorer, such as Blockscout, and search for the address of the smart contract, you will see that it has bytecode.
 
-However, to add more details, you need to verify the contract.
+However, to see aditional details, you need to verify the contract.
 
 ```bash
 forge verify-contract \

--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -76,7 +76,7 @@ Be sure to copy the address at which the smart contract was deployed, as you wil
 
 After the deployment is completed, if you visit a network explorer, such as Blockscout, and search for the address of the smart contract, you will see that it has bytecode.
 
-However, to add more details you need to verify the contract.
+However, to add more details, you need to verify the contract.
 
 ```bash
 forge verify-contract \

--- a/.gitbook/developers/evm-developers/guides/testnet-deployment.md
+++ b/.gitbook/developers/evm-developers/guides/testnet-deployment.md
@@ -45,19 +45,7 @@ cd path/to/your/project
 Your private key should have INJ on the Injective network. A transaction will be created which requires a gas fee. You can request EVM testnet funds [here](https://testnet.faucet.injective.network/)
 {% endhint %}
 
-This command creates a transaction, but simply displays it without submitting it to the network. Therefore the smart contract does not get deployed.
-
-```shell
-# Simulating
-forge create \
-  src/{YourContract}.sol:{ContractName} \
-  --rpc-url injectiveEvm \
-  --legacy \
-  --private-key \
-  {YourPrivateKey}
-```
-
-This command does the same as above, but submits it to the network. Therefore the smart contract should get deployed.
+This command creates a transaction, and submits it to the network. If the transaction is successful, the smart contract will be deployed, and the address it is deployed at will be output.
 
 ```shell
 # Broadcasting
@@ -70,7 +58,6 @@ forge create \
 ```
 
 Be sure to copy the address at which the smart contract was deployed, as you will need to use it in subsequent commands.
-
 
 ### Verifying on Blockscout
 

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -156,7 +156,7 @@ First use `cast sig`, this time on a different function:
 cast sig "function increment()"
 ```
 
-This should produce a different function signature from before, since it is another function:
+This should produce a different function signature from before, as points to a different function:
 
 ```text
 0xd09de08a
@@ -175,6 +175,6 @@ cast send \
 
 If you visit the smart contract address in a block explorer, you should see the new transaction registered against it.
 
-If you repeat the `cast call` command above which invokes `number()`, you should get an updated value of `1` this time.
+If you repeat the `cast call` command above, which invokes `number()`, you should get an updated value of `1` this time.
 
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th data-type="content-ref"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>← Previous</td><td><a href="../evm-developers.md">evm-developers.md</a></td><td><a href="../evm-developers.md">evm-developers.md</a></td></tr><tr><td>Next →</td><td><a href="guides/">guides</a></td><td><a href="guides/">guides</a></td></tr></tbody></table>

--- a/.gitbook/developers/evm-developers/your-first-smart-contract.md
+++ b/.gitbook/developers/evm-developers/your-first-smart-contract.md
@@ -41,9 +41,9 @@ Note that the version used in this tutorial was `1.2.3-stable`. Be sure to use t
 {% hint style="info" %}
 If you are starting a new project from scratch:
 
-- Create a new directory for the project
-- Create a new `foundry.toml` file inside it
-- Create an `src` subdirectory
+* Create a new directory for the project
+* Create a new `foundry.toml` file inside it
+* Create an `src` subdirectory
 
 ```shell
 mkdir my-first-smart-contract-inj
@@ -156,7 +156,7 @@ First use `cast sig`, this time on a different function:
 cast sig "function increment()"
 ```
 
-This should produce a different function signature from befoe, since it is another function:
+This should produce a different function signature from before, since it is another function:
 
 ```text
 0xd09de08a
@@ -173,8 +173,8 @@ cast send \
   0xd09de08a
 ```
 
-If you visit the smart contract address in a block exporer, you should see the new transaction registered against it.
+If you visit the smart contract address in a block explorer, you should see the new transaction registered against it.
 
-If you repeat the `cast call` command above which invoke `number()`, you should get an updated value of `1` this time.
+If you repeat the `cast call` command above which invokes `number()`, you should get an updated value of `1` this time.
 
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th data-type="content-ref"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>← Previous</td><td><a href="../evm-developers.md">evm-developers.md</a></td><td><a href="../evm-developers.md">evm-developers.md</a></td></tr><tr><td>Next →</td><td><a href="guides/">guides</a></td><td><a href="guides/">guides</a></td></tr></tbody></table>


### PR DESCRIPTION
- removed the dryrun `forge create`, as it does not exist, according to the foundry docs
  - ref: https://getfoundry.sh/forge/reference/forge-create
- misc other typos/ syntax fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved clarity in the testnet deployment guide by removing outdated simulation steps and refining instructions for contract deployment.
  - Fixed typos and standardized bullet point formatting in the smart contract tutorial for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->