### PR TITLE
fix: add more redirects needed, discovered in injective.com site

### DIFF
--- a/.gitbook/.gitbook.yaml
+++ b/.gitbook/.gitbook.yaml
@@ -6,6 +6,15 @@ structure:
 
 redirects:
   develop/public-endpoints: nodes/public-endpoints.md
+  guides: developers/README.md
+  develop/cheat-sheet: developers/README.md
+  develop/tech-concepts: developers/README.md
+  nodes/RunNode/testnet: infra/run-node.md
+  develop/tools: developers/injectived/README.md
+  develop/guides: developers/README.md
+  develop/modules: developers-native/README.md
+  develop/modules/Core/auth: developers-native/core/auth/README.md
+  develop/guides/cosmwasm-dapps: developers-cosmwasm/create-uis-guide.md
   getting-started: README.md
   getting-started/wallet: defi/wallet/README.md
   getting-started/wallet/create-a-wallet: defi/wallet/create.md


### PR DESCRIPTION
These have existing redirects configured, but gitbook is not rendering them. Plan to follow up with Gitbook support on on the rendering mismatch:

-   developers/getting-started
-   toolkits
-   developers/modules
-   nodes/getting-started/interact-with-a-node
-   nodes/getting-started/running-a-node
-   nodes/validators/mainnet/canonical-chain-upgrades
-   nodes/private-nodes
-   guides/launch-a-token
-   nodes/public-endpoints

These already work:

-   references

These redirects are added in this PR:

-   guides --> /developers/
-   develop/cheat-sheet --> /developers/
-   develop/tech-concepts --> /developers/
-   nodes/RunNode/testnet --> /infra/run-node/
-   develop/tools --> /developers/injectived/
-   develop/guides --> /developers/
-   develop/modules --> /developers-native/
-   develop/modules/Core/auth --> /developers-native/core/auth/
-   develop/guides/cosmwasm-dapps --> /developers-cosmwasm/create-uis-guide/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new redirects for various documentation paths to improve navigation and access to developer guides, cheat sheets, technical concepts, tools, and modules. No existing redirects were changed or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->