### PR TITLE
docs: minor tweak to shift glossary and references to bottom of nav tree (after all 6 personas)

### DIFF
--- a/.gitbook/SUMMARY.md
+++ b/.gitbook/SUMMARY.md
@@ -1,8 +1,6 @@
 # Table of contents
 
 * [About Injective](README.md)
-* [Glossary](glossary.md)
-* [References](references.md)
 * [DeFi](defi/README.md)
   * [Wallet](defi/wallet/README.md)
     * [Create a wallet](defi/wallet/create.md)
@@ -213,3 +211,5 @@
     * [Upgrade](developers-native/core/upgrade/README.md)
     * [Circuit](developers-native/core/circuit/README.md)
     * [Genutil](developers-native/core/genutil/README.md)
+* [Glossary](glossary.md)
+* [References](references.md)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Moved the "Glossary" and "References" sections to the end of the table of contents for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->