### PR TITLE
docs: add ext links for the graph substreams and subgraphs

### DIFF
--- a/.gitbook/developers-evm/infrastructure-and-tooling.md
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.md
@@ -12,7 +12,15 @@ BlockScoutInjective is supported by a rich ecosystem of industry-leading infrast
 
 ### **Data Indexing & Querying**
 
-<table data-header-hidden><thead><tr><th width="150.27734375"></th><th></th></tr></thead><tbody><tr><td><a href="https://thegraph.com/networks/injective/?subnetwork=injective-testnet">The Graph</a></td><td>The Graph’s state-of-the-art Substreams and Substreams-powered subgraph solution, developed by <a href="https://www.streamingfast.io/?ref=blog.injective.com">StreamingFast</a>, Injective provides developers seamless access to on-chain data.</td></tr></tbody></table>
+<table data-header-hidden><thead><tr><th width="150.27734375"></th><th></th></tr></thead><tbody>
+<tr><td><a href="https://thegraph.com/networks/injective/?subnetwork=injective-testnet">The Graph</a></td><td>
+The Graph’s state-of-the-art Substreams and Substreams-powered subgraph solution, developed by <a href="https://www.streamingfast.io/">StreamingFast</a>, Injective provides developers seamless access to on-chain data.
+<br />
+<a href="https://docs.substreams.dev/tutorials/intro-to-tutorials/injective">Substreams Injective quick start</a>
+<br />
+<a href="https://thegraph.com/docs/en/subgraphs/quick-start/">Subgraphs Injective quick start</a>
+</td></tr>
+</tbody></table>
 
 ### Block Explorers
 

--- a/.gitbook/developers-evm/infrastructure-and-tooling.md
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.md
@@ -14,12 +14,17 @@ BlockScoutInjective is supported by a rich ecosystem of industry-leading infrast
 
 <table data-header-hidden><thead><tr><th width="150.27734375"></th><th></th></tr></thead><tbody>
 <tr><td><a href="https://thegraph.com/networks/injective/?subnetwork=injective-testnet">The Graph</a></td><td>
-The Graph’s state-of-the-art Substreams and Substreams-powered subgraph solution, developed by <a href="https://www.streamingfast.io/">StreamingFast</a>, Injective provides developers seamless access to on-chain data.
-<br />
+<p>
+The Graph’s state-of-the-art Substreams and Substreams-powered subgraph solution, developed by <a href="https://www.streamingfast.io/">StreamingFast</a> for Injective, provides developers seamless access to on-chain data.
+</p>
+<ul>
+<li>
 <a href="https://docs.substreams.dev/tutorials/intro-to-tutorials/injective">Substreams Injective quick start</a>
-<br />
+</li>
+<li>
 <a href="https://thegraph.com/docs/en/subgraphs/quick-start/">Subgraphs Injective quick start</a>
-</td></tr>
+</li>
+</ul>
 </tbody></table>
 
 ### Block Explorers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the "Data Indexing & Querying" section with additional quick start links for Substreams and Subgraphs on Injective.
  * Updated content to highlight StreamingFast's role in developing the Substreams and subgraph solutions for Injective.
  * Reformatted resource presentation for improved clarity and direct access to tutorials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->