### PR TITLE
docs: add EVM mainnet network information

### DIFF
--- a/.gitbook/developers-evm/network-information.md
+++ b/.gitbook/developers-evm/network-information.md
@@ -7,16 +7,34 @@ description: Essential information about the Injective EVM network
 ## Injective EVM Testnet Details
 
 * Chain ID: `1439`
-* JSON-RPC Endpoint: `https://k8s.testnet.json-rpc.injective.network/`\
+* JSON-RPC Endpoint: `https://k8s.testnet.json-rpc.injective.network/`
 * WS Endpoint: `https://k8s.testnet.ws.injective.network/`
-* Faucet: [`https://testnet.faucet.injective.network/`](https://testnet.faucet.injective.network/)
-* Explorer: [`https://testnet.blockscout.injective.network/`](https://testnet.blockscout.injective.network/)
-* Explorer (mirror by Blockscout): [`https://testnet-injective.cloud.blockscout.com/`](https://testnet-injective.cloud.blockscout.com/)
+* Faucet: [`testnet.faucet.injective.network/`](https://testnet.faucet.injective.network/)
+* Explorer: [`testnet.blockscout.injective.network/`](https://testnet.blockscout.injective.network/)
+* Explorer (mirror by Blockscout): [`testnet-injective.cloud.blockscout.com/`](https://testnet-injective.cloud.blockscout.com/)
 * Explorer API: `https://testnet.blockscout-api.injective.network/api`
 
 {% hint style="info" %}
 Note that the Injective Chain ID is natively `injective-888`.
 However, EVM uses a numeric chain ID of `1439`.
+While these are different, they map to the **same** network.
+
+See [network information](../developers/network-information.md) for more details.
+{% endhint %}
+
+## Injective EVM Mainnet Details
+
+* Chain ID: `1776`
+* JSON-RPC Endpoint: `https://json-rpc.injective.network/`
+* WS Endpoint: `https://ws.injective.network/`
+* Faucet: N/A, to obtain Mainnet INJ see [`injective.com/getinj/`](https://injective.com/getinj/)
+* Explorer: [`blockscout.injective.network`](https://blockscout.injective.network/)
+* Explorer (mirror by Blockscout): [`injective.cloud.blockscout.com`](https://injective.cloud.blockscout.com)
+* Explorer API: `https://blockscout-api.injective.network`
+
+{% hint style="info" %}
+Note that the Injective Chain ID is natively `injective-1`.
+However, EVM uses a numeric chain ID of `1776`.
 While these are different, they map to the **same** network.
 
 See [network information](../developers/network-information.md) for more details.

--- a/.gitbook/developers-evm/network-information.md
+++ b/.gitbook/developers-evm/network-information.md
@@ -7,8 +7,8 @@ description: Essential information about the Injective EVM network
 ## Injective EVM Mainnet Details
 
 * Chain ID: `1776`
-* JSON-RPC Endpoint: `https://json-rpc.injective.network/`
-* WS Endpoint: `https://ws.injective.network/`
+* JSON-RPC Endpoint: `https://sentry.evm-rpc.injective.network/`
+* WS Endpoint: `wss://sentry.evm-ws.injective.network`
 * Faucet: N/A, to obtain Mainnet INJ see [`injective.com/getinj`](https://injective.com/getinj/)
 * Explorer: [`blockscout.injective.network`](https://blockscout.injective.network/)
 * Explorer API: `https://blockscout-api.injective.network`

--- a/.gitbook/developers-evm/network-information.md
+++ b/.gitbook/developers-evm/network-information.md
@@ -4,6 +4,30 @@ description: Essential information about the Injective EVM network
 
 # EVM Network Information
 
+## Injective EVM Mainnet Details
+
+* Chain ID: `1776`
+* JSON-RPC Endpoint: `https://json-rpc.injective.network/`
+* WS Endpoint: `https://ws.injective.network/`
+* Faucet: N/A, to obtain Mainnet INJ see [`injective.com/getinj`](https://injective.com/getinj/)
+* Explorer: [`blockscout.injective.network`](https://blockscout.injective.network/)
+* Explorer API: `https://blockscout-api.injective.network`
+
+{% hint style="info" %}
+Note that the Injective Chain ID is natively `injective-1`.
+However, EVM uses a numeric chain ID of `1776`.
+While these are different, they map to the **same** network.
+
+See [network information](../developers/network-information.md) for more details.
+{% endhint %}
+
+### More Providers
+
+* Explorer - Blockscout mirror: [`injective.cloud.blockscout.com`](https://injective.cloud.blockscout.com)
+* JSON-RPC - Quicknode [`quicknode.com/chains/inj`](https://www.quicknode.com/chains/inj)
+  * Note that you will need to create an account on quicknode to obtain an endpoint URL
+  * [Quicknode JSON-RPC documentation](https://www.quicknode.com/docs/injective/evm/eth_blockNumber)
+
 ## Injective EVM Testnet Details
 
 * Chain ID: `1439`
@@ -11,7 +35,6 @@ description: Essential information about the Injective EVM network
 * WS Endpoint: `https://k8s.testnet.ws.injective.network/`
 * Faucet: [`testnet.faucet.injective.network/`](https://testnet.faucet.injective.network/)
 * Explorer: [`testnet.blockscout.injective.network/`](https://testnet.blockscout.injective.network/)
-* Explorer (mirror by Blockscout): [`testnet-injective.cloud.blockscout.com/`](https://testnet-injective.cloud.blockscout.com/)
 * Explorer API: `https://testnet.blockscout-api.injective.network/api`
 
 {% hint style="info" %}
@@ -22,23 +45,9 @@ While these are different, they map to the **same** network.
 See [network information](../developers/network-information.md) for more details.
 {% endhint %}
 
-## Injective EVM Mainnet Details
+### More Providers
 
-* Chain ID: `1776`
-* JSON-RPC Endpoint: `https://json-rpc.injective.network/`
-* WS Endpoint: `https://ws.injective.network/`
-* Faucet: N/A, to obtain Mainnet INJ see [`injective.com/getinj/`](https://injective.com/getinj/)
-* Explorer: [`blockscout.injective.network`](https://blockscout.injective.network/)
-* Explorer (mirror by Blockscout): [`injective.cloud.blockscout.com`](https://injective.cloud.blockscout.com)
-* Explorer API: `https://blockscout-api.injective.network`
-
-{% hint style="info" %}
-Note that the Injective Chain ID is natively `injective-1`.
-However, EVM uses a numeric chain ID of `1776`.
-While these are different, they map to the **same** network.
-
-See [network information](../developers/network-information.md) for more details.
-{% endhint %}
+* Explorer - Blockscout mirror: [`testnet-injective.cloud.blockscout.com/`](https://testnet-injective.cloud.blockscout.com/)
 
 ### Tokens
 
@@ -56,7 +65,3 @@ For more information about Injective EVM Testnet see the following pages:
   * [EVM Equivalence](evm-equivalence.md)
   * [MultiVM Token Standard](multivm-token-standard.md)
   * [Precompiles](./precompiles.md)
-
-## Injective EVM Mainnet
-
-Coming soon.

--- a/.gitbook/developers/network-information.md
+++ b/.gitbook/developers/network-information.md
@@ -26,3 +26,11 @@ See [EVM network information](../developers-evm/network-information.md) for more
 
 * Chain ID: `injective-1`
 * Node: `https://sentry.tm.injective.network:443`
+
+{% hint style="info" %}
+Note that the Injective Chain ID for EVM is `1776`.
+However, it natively uses a chain ID of `injective-1`.
+While the chain IDs are different, they map to the **same** network.
+
+See [EVM network information](../developers-evm/network-information.md) for more details.
+{% endhint %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Injective EVM network documentation to include detailed Mainnet information, such as chain ID, endpoints, explorer links, and provider options.
  * Clarified the distinction between EVM and native Injective chain IDs in both EVM and general network documentation.
  * Updated and formatted Testnet provider information and improved clarity of related documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->