### PR TITLE
docs: add instruction for verifying each released version

### DIFF
--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade.md
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade.md
@@ -2,13 +2,15 @@
 
 ## Verify release versions
 
+### Releases on Github
+
 If you would like to verify `injectived` or `peggo` version numbers via Docker,
 follow the instructions in the [`verify-injective-release`](https://github.com/injective-dev/snippets-inj/tree/main/verify-injective-release) code snippet.
 
 This is useful if you are on an operating system other than Linux,
 and would like to independently verify the binaries in each release.
 
-For example, for v1.16.1, it should produce the following output:
+For example, for `v1.16.1`, it should produce the following output:
 
 ```text
 injectived version
@@ -19,8 +21,43 @@ Version v1.16.1 (8be67e82d)
 Compiled at 20250802-1913 using Go go1.23.9 (amd64)
 ```
 
-Note that this contains not only the version numbers (e.g. `v.1.16.1`),
-but also contains the following:
+### Releases on Docker
+
+These are more straightforward, as each binary needs a single command.
+
+For `injectived`, use the following command:
+
+```shell
+docker run -it --rm injectivelabs/injective-core:v1.16.1 injectived version
+```
+
+This should produce output similar to:
+
+```text
+Version v1.16.1 (8be67e8)
+Compiled at 20250802-1909 using Go go1.23.9 (arm64)
+```
+
+For `peggo`, use the following command:
+
+```shell
+docker run -it --rm injectivelabs/injective-core:v1.16.1 peggo version
+```
+
+This should produce output similar to:
+
+```text
+Version v1.16.1 (8be67e8)
+Compiled at 20250802-1911 using Go go1.23.9 (arm64)
+```
+
+Note that you should replace `v1.16.1` in the commands above
+with your intended Injective release version number.
+
+### Checking for matches
+
+Note that the output from the above commmands contain
+the following in addition to the version numbers (e.g. `v1.16.1`):
 
 - The binary release hashes (e.g. `8be67e82d`)
 - The compiled time stamp (e.g. `20250802-1910`)

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade.md
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade.md
@@ -1,5 +1,33 @@
 # Canonical Chain Upgrades
 
+## Verify release versions
+
+If you would like to verify `injectived` or `peggo` version numbers via Docker,
+follow the instructions in the [`verify-injective-release`](https://github.com/injective-dev/snippets-inj/tree/main/verify-injective-release) code snippet.
+
+This is useful if you are on an operating system other than Linux,
+and would like to independently verify the binaries in each release.
+
+For example, for v1.16.1, it should produce the following output:
+
+```text
+injectived version
+Version v1.16.1 (8be67e82d)
+Compiled at 20250802-1910 using Go go1.23.9 (amd64)
+peggo version
+Version v1.16.1 (8be67e82d)
+Compiled at 20250802-1913 using Go go1.23.9 (amd64)
+```
+
+Note that this contains not only the version numbers (e.g. `v.1.16.1`),
+but also contains the following:
+
+- The binary release hashes (e.g. `8be67e82d`)
+- The compiled time stamp (e.g. `20250802-1910`)
+- The compiler (e.g. `Go go1.23.9 (amd64)`)
+
+You can verify that these **match** the values stated in the [Injective chain releases](https://github.com/InjectiveLabs/injective-chain-releases/releases) page on Github.
+
 ## History of Canonical Chain Upgrades
 
 ***


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section with instructions for verifying the release versions of injectived and peggo binaries using Docker, including example outputs and guidance on matching official release details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->