### PR TITLE
docs: minor - fixed a broken link in /defi/transactions/

### DIFF
--- a/.gitbook/defi/transactions.md
+++ b/.gitbook/defi/transactions.md
@@ -8,7 +8,7 @@ After being broadcasted and passing all validations (including signature validat
 
 In simpler terms, messages are the instructions given to Injective about the desired state change. Messages are module-specific objects that trigger state transitions within the scope of the module they belong to. Every transaction must have at least one message.
 
-**Additionally, multiple messages can be packed within the same transaction.** Available Messages from each module can be found in the [modules](../../developers/modules/ "mention")section.
+**Additionally, multiple messages can be packed within the same transaction.** Available Messages from each module can be found in the [native developers](../developers-native/ "mention") section.
 
 ### Transaction Context
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Messages section hyperlink to point to the Native Developers documentation instead of Modules, improving accuracy of cross-references for where message availability is documented.
  * Link text now reads “native developers”; surrounding sentence remains unchanged.
  * No behavioral or functional changes; this is a navigation and clarity improvement within the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->