### PR TITLE
docs: chain v1.16.2

### DIFF
--- a/.gitbook/SUMMARY.md
+++ b/.gitbook/SUMMARY.md
@@ -35,6 +35,7 @@
   * [Mainnet Validator](infra/validator-mainnet/README.md)
     * [Peggo](infra/validator-mainnet/peggo.md)
     * [Canonical Chain Upgrades](infra/validator-mainnet/canonical-chain-upgrade.md)
+    * [v1.16.2](infra/validator-mainnet/canonical-chain-upgrade-1.16.2.md)
     * [v1.16.1](infra/validator-mainnet/canonical-chain-upgrade-1.16.1.md)
     * [v1.16.0](infra/validator-mainnet/canonical-chain-upgrade-1.16.0.md)
     * [v1.15.0](infra/validator-mainnet/canonical-chain-upgrade-1.15.0.md)

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.16.2.md
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.16.2.md
@@ -1,8 +1,8 @@
-# Upgrade to v1.16.1
+# Upgrade to v1.16.2
 
-Monday, August 4th, 2025
+Tuesday, August 19th, 2025
 
-Following [Proposal 544](https://injhub.com/proposal/544/) This indicates that the upgrade procedure should be performed on block number **127714000**
+Following [Proposal 550](https://injhub.com/proposal/550/) This indicates that the upgrade procedure should be performed on block number **129772500**
 
 * [Summary](#summary)
 * [Recovery](#recovery)
@@ -11,13 +11,13 @@ Following [Proposal 544](https://injhub.com/proposal/544/) This indicates that t
 
 ## Summary
 
-The Injective Chain will undergo a scheduled enhancement upgrade on **Monday, August 4th, 2025, 12:00 UTC**.
+The Injective Chain will undergo a scheduled enhancement upgrade on **Tuesday, August 19th, 2025, 14:00 UTC**.
 
 The following is a short summary of the upgrade steps:
 
-1. Vote and wait till the node panics at block height **127714000**.
+1. Vote and wait till the node panics at block height **129772500**.
 2. Backing up configs, data, and keys used for running the Injective Chain.
-3. Install the [v1.16.1](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.1-1754161770) binaries.
+3. Install the [v1.16.2]https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.2-1755212690) binaries.
 4. Start your node with the new injectived binary to fulfill the upgrade.
 
 Upgrade coordination and support for validators will be available on the `#validators` private channel of the [Injective Discord](https://discord.gg/injective).
@@ -38,7 +38,7 @@ Prior to exporting chain state, validators are encouraged to take a full data sn
 
 It is critically important to backup the `.injectived/data/priv_validator_state.json` file after stopping your injectived process. This file is updated every block as your validator participates in a consensus rounds. It is a critical file needed to prevent double-signing, in case the upgrade fails and the previous chain needs to be restarted.
 
-In the event that the upgrade does not succeed, validators and operators must restore the snapshot and downgrade back to Injective Chain release [v1.16.0](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.0-1753404855) and continue this earlier chain until next upgrade announcement.
+In the event that the upgrade does not succeed, validators and operators must restore the snapshot and downgrade back to Injective Chain release [v1.16.1](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.1-1754161770) and continue this earlier chain until next upgrade announcement.
 
 ### Upgrade Procedure
 
@@ -64,20 +64,20 @@ rm -rf .injectived/wasm/wasm/cache/
     cp ~/.injectived ./injectived-backup
     ```
 
-3. Download and install the `injective-chain` release for `v1.16.1`:
+3. Download and install the `injective-chain` release for `v1.16.2`:
 
     ```bash
-    wget https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.16.1-1754161770/linux-amd64.zip
+    wget https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.16.2-1755212690/linux-amd64.zip
     unzip linux-amd64.zip
     sudo mv injectived peggo /usr/bin
     sudo mv libwasmvm.x86_64.so /usr/lib
     ```
 
-4.  Verify you are currently running the correct version (`v1.16.1`) of `injectived` after downloading the`v1.16.1` release:
+4.  Verify you are currently running the correct version (`v1.16.2`) of `injectived` after downloading the`v1.16.2` release:
 
     ```bash
-    Version v1.16.1 (8be67e82d)
-    Compiled at 20250802-1910 using Go go1.23.9
+    Version v1.16.2 (437674d)
+    Compiled at 20250814-2305 using Go go1.23.9
     ```
 
 5.  Start `injectived`:
@@ -86,11 +86,11 @@ rm -rf .injectived/wasm/wasm/cache/
     injectived start
     ```
 
-6.  Verify you are currently running the correct version (`v1.16.1`) of `peggo` after downloading the `v1.16.1` release:
+6.  Verify you are currently running the correct version (`v1.16.2`) of `peggo` after downloading the `v1.16.2` release:
 
     ```bash
-    Version v1.16.1 (8be67e82d)
-    Compiled at 20250802-1913 using Go go1.23.9
+    Version v1.16.2 (437674d)
+    Compiled at 20250814-2307 using Go go1.23.9
     ```
 
 7.  Start peggo:

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.16.2.md
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.16.2.md
@@ -1,0 +1,100 @@
+# Upgrade to v1.16.1
+
+Monday, August 4th, 2025
+
+Following [Proposal 544](https://injhub.com/proposal/544/) This indicates that the upgrade procedure should be performed on block number **127714000**
+
+* [Summary](#summary)
+* [Recovery](#recovery)
+* [Upgrade Procedure](#upgrade-procedure)
+* [Notes for Validators](#notes-for-validators)
+
+## Summary
+
+The Injective Chain will undergo a scheduled enhancement upgrade on **Monday, August 4th, 2025, 12:00 UTC**.
+
+The following is a short summary of the upgrade steps:
+
+1. Vote and wait till the node panics at block height **127714000**.
+2. Backing up configs, data, and keys used for running the Injective Chain.
+3. Install the [v1.16.1](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.1-1754161770) binaries.
+4. Start your node with the new injectived binary to fulfill the upgrade.
+
+Upgrade coordination and support for validators will be available on the `#validators` private channel of the [Injective Discord](https://discord.gg/injective).
+
+The network upgrade can take the following potential pathways:
+
+1. **Happy path**:\
+   Validators successfully upgrade the chain without purging the blockchain history, and all validators are up within 5-10 minutes of the upgrade.
+2. **Not-so-happy path**:\
+   Validators have trouble upgrading to the latest Canonical chain.
+3. **Abort path**:\
+   In the rare event that the team becomes aware of unnoticed critical issues, the Injective team will attempt to patch all the breaking states and provide another official binary within 36 hours.\
+   If the chain is not successfully resumed within 36 hours, the upgrade will be announced as aborted on the `#validators` channel in [Injective's Discord](https://discord.gg/injective), and validators will need to resume running the chain without any updates or changes.
+
+## Recovery
+
+Prior to exporting chain state, validators are encouraged to take a full data snapshot at the export height before proceeding. Snapshotting depends heavily on infrastructure, but generally this can be done by backing up the `.injectived` directory.
+
+It is critically important to backup the `.injectived/data/priv_validator_state.json` file after stopping your injectived process. This file is updated every block as your validator participates in a consensus rounds. It is a critical file needed to prevent double-signing, in case the upgrade fails and the previous chain needs to be restarted.
+
+In the event that the upgrade does not succeed, validators and operators must restore the snapshot and downgrade back to Injective Chain release [v1.16.0](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.0-1753404855) and continue this earlier chain until next upgrade announcement.
+
+### Upgrade Procedure
+
+## Notes for Validators
+
+You must remove the wasm cache before upgrading to the new version:
+
+```shell
+rm -rf .injectived/wasm/wasm/cache/
+```
+
+1.  Verify you are currently running the correct version (`v1.16.0`) of `injectived`:
+
+    ```bash
+    $ injectived version
+    Version v1.16.0 (95706035d)
+    Compiled at 20250725-0055 using Go go1.23.9 (amd64)
+    ```
+
+2.  Make a backup of your `.injectived` directory:
+
+    ```bash
+    cp ~/.injectived ./injectived-backup
+    ```
+
+3. Download and install the `injective-chain` release for `v1.16.1`:
+
+    ```bash
+    wget https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.16.1-1754161770/linux-amd64.zip
+    unzip linux-amd64.zip
+    sudo mv injectived peggo /usr/bin
+    sudo mv libwasmvm.x86_64.so /usr/lib
+    ```
+
+4.  Verify you are currently running the correct version (`v1.16.1`) of `injectived` after downloading the`v1.16.1` release:
+
+    ```bash
+    Version v1.16.1 (8be67e82d)
+    Compiled at 20250802-1910 using Go go1.23.9
+    ```
+
+5.  Start `injectived`:
+
+    ```bash
+    injectived start
+    ```
+
+6.  Verify you are currently running the correct version (`v1.16.1`) of `peggo` after downloading the `v1.16.1` release:
+
+    ```bash
+    Version v1.16.1 (8be67e82d)
+    Compiled at 20250802-1913 using Go go1.23.9
+    ```
+
+7.  Start peggo:
+
+    ```bash
+    peggo orchestrator
+    ```

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.16.2.md
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.16.2.md
@@ -17,7 +17,7 @@ The following is a short summary of the upgrade steps:
 
 1. Vote and wait till the node panics at block height **129772500**.
 2. Backing up configs, data, and keys used for running the Injective Chain.
-3. Install the [v1.16.2]https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.2-1755212690) binaries.
+3. Install the [v1.16.2](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.16.2-1755212690) binaries.
 4. Start your node with the new injectived binary to fulfill the upgrade.
 
 Upgrade coordination and support for validators will be available on the `#validators` private channel of the [Injective Discord](https://discord.gg/injective).
@@ -50,12 +50,12 @@ You must remove the wasm cache before upgrading to the new version:
 rm -rf .injectived/wasm/wasm/cache/
 ```
 
-1.  Verify you are currently running the correct version (`v1.16.0`) of `injectived`:
+1.  Verify you are currently running the correct version (`v1.16.1`) of `injectived`:
 
     ```bash
     $ injectived version
-    Version v1.16.0 (95706035d)
-    Compiled at 20250725-0055 using Go go1.23.9 (amd64)
+    Version v1.16.1 (8be67e82d)
+    Compiled at 20250802-1913 using Go go1.23.9
     ```
 
 2.  Make a backup of your `.injectived` directory:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical chain upgrade guide for Injective Chain v1.16.2 with schedule (Aug 19, 2025, 14:00 UTC), target height (129,772,500), upgrade paths (happy/not-so-happy/abort), recovery guidance, validator notes, and step-by-step upgrade/rollback commands.
  * Updated documentation TOC to include the new v1.16.2 entry under Mainnet Validator → Canonical Chain Upgrades, placed before v1.16.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->